### PR TITLE
adds new `Kube.assert.matches` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ matches some expectation:
 * `kube.assert.unknown`: (optional) bool indicating the test author expects the
   Kubernetes API server to respond that it does not know the type of resource
   attempting to be fetched or created.
+* `kube.assert.matches`: (optional) a YAML string, a filepath, or a
+  `map[string]interface{}` representing the content that you expect to find in
+  the returned result from the `kube.get` call.
+  If `kube.assert.matches` is a
+  string, the string can be either a file path to a YAML manifest or
+  inline an YAML string containing the resource fields to compare.
+  Only fields present in the Matches resource are compared. There is a
+  check for existence in the retrieved resource as well as a check that
+  the value of the fields match. Only scalar fields are matched entirely.
+  In other words, you do not need to specify every field of a struct field
+  in order to compare the value of a single field in the nested struct.
 
 Here are some examples of `gdt-kube` tests.
 
@@ -241,6 +252,54 @@ tests:
   - kube.create: manifests/deployment.yaml
   - exec: sleep 30
   - exec: ssh -T someuser@ip
+```
+
+A test that checks that a Deployment resource's `Status.ReadyReplicas` field
+is `2`. You do not need to specify all other `Deployment.Status` fields like
+`Status.Replicas` in order to match the `Status.ReadyReplicas` field value. You
+only need to include the `Status.ReadyReplicas` field in the `Matches` value as
+these examples demonstrate:
+
+```yaml
+tests:
+ - name: check deployment's ready replicas is 2
+   kube:
+     get: deployments/my-deployment
+     assert:
+       matches: |
+         kind: Deployment
+         metadata:
+           name: my-deployment
+         status:
+           readyReplicas: 2
+```
+
+you don't even need to include the kind and metadata in `kube.assert.matches`.
+If missing, no kind and name matching will be performed.
+
+```yaml
+tests:
+ - name: check deployment's ready replicas is 2
+   kube:
+     get: deployments/my-deployment
+     assert:
+       matches: |
+         status:
+           readyReplicas: 2
+```
+
+In fact, you don't need to use an inline multiline YAML string. You can
+use a `map[string]interface{}` as well:
+
+```yaml
+tests:
+ - name: check deployment's ready replicas is 2
+   kube:
+     get: deployments/my-deployment
+     assert:
+       matches:
+         status:
+           readyReplicas: 2
 ```
 
 ## Determining Kubernetes config, context and namespace values

--- a/assertions.go
+++ b/assertions.go
@@ -16,11 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const (
-	msgExpectedError = "Expected response to have error containing %s but got %s"
-	msgExpectedLen   = "Expected response to have %d items in result but got %d"
-)
-
 // Expect contains one or more assertions about a kube client call
 type Expect struct {
 	// Error is a string that is expected to be returned as an error string
@@ -42,6 +37,66 @@ type Expect struct {
 	// from the Kubernetes API server. This is mostly good for unit/fuzz
 	// testing CRDs.
 	Unknown bool `yaml:"unknown,omitempty"`
+	// Matches is either a string or a map[string]interface{} containing the
+	// resource that the `Kube.Get` should match against. If Matches is a
+	// string, the string can be either a file path to a YAML manifest or
+	// inline an YAML string containing the resource fields to compare.
+	//
+	// Only fields present in the Matches resource are compared. There is a
+	// check for existence in the retrieved resource as well as a check that
+	// the value of the fields match. Only scalar fields are matched entirely.
+	// In other words, you do not need to specify every field of a struct field
+	// in order to compare the value of a single field in the nested struct.
+	//
+	// As an example, imagine you wanted to check that a Deployment resource's
+	// `Status.ReadyReplicas` field was 2. You do not need to specify all other
+	// `Deployment.Status` fields like `Status.Replicas` in order to match the
+	// `Status.ReadyReplicas` field value. You only need to include the
+	// `Status.ReadyReplicas` field in the `Matches` value as these examples
+	// demonstrate:
+	//
+	// ```yaml
+	// tests:
+	//  - name: check deployment's ready replicas is 2
+	//    kube:
+	//      get: deployments/my-deployment
+	//      assert:
+	//        matches: |
+	//          kind: Deployment
+	//          metadata:
+	//            name: my-deployment
+	//          status:
+	//            readyReplicas: 2
+	// ```
+	//
+	// you don't even need to include the kind and metadata in `Matches`. If
+	// missing, no kind and name matching will be performed.
+	//
+	// ```yaml
+	// tests:
+	//  - name: check deployment's ready replicas is 2
+	//    kube:
+	//      get: deployments/my-deployment
+	//      assert:
+	//        matches: |
+	//          status:
+	//            readyReplicas: 2
+	// ```
+	//
+	// In fact, you don't need to use an inline multiline YAML string. You can
+	// use a `map[string]interface{}` as well:
+	//
+	// ```yaml
+	// tests:
+	//  - name: check deployment's ready replicas is 2
+	//    kube:
+	//      get: deployments/my-deployment
+	//      assert:
+	//        matches:
+	//          status:
+	//            readyReplicas: 2
+	// ```
+	Matches interface{} `yaml:"matches,omitempty"`
 }
 
 // assertions contains all assertions made for the exec test
@@ -100,13 +155,10 @@ func (a *assertions) OK() bool {
 	if !a.errorOK() {
 		return false
 	}
-	if !a.unknownOK() {
-		return false
-	}
-	if !a.notFoundOK() {
-		return false
-	}
 	if !a.lenOK() {
+		return false
+	}
+	if !a.matchesOK() {
 		return false
 	}
 	return true
@@ -116,7 +168,36 @@ func (a *assertions) OK() bool {
 // false otherwise.
 func (a *assertions) errorOK() bool {
 	exp := a.exp
-	if exp.Error != "" {
+	// We first evaluate whether an error we have received should be
+	// "swallowed" because it was expected. If we still have an error after
+	// swallowing all unexpected errors, then that is an unexpected error and
+	// we fail.
+	if a.err != nil {
+		if errors.Is(a.err, ErrResourceUnknown) {
+			if !exp.Unknown {
+				a.Fail(a.err)
+				a.terminal = true
+				return false
+			}
+			// "Swallow" the Unknown error since we expected it.
+			a.err = nil
+		}
+		// check if the error is like one returned from Get or Delete
+		// that has a 404 ErrStatus.Code in it
+		apierr, ok := a.err.(*apierrors.StatusError)
+		if ok {
+			if !a.expectsNotFound() {
+				if http.StatusNotFound != int(apierr.ErrStatus.Code) {
+					msg := fmt.Sprintf("got status code %d", apierr.ErrStatus.Code)
+					a.Fail(ExpectedNotFound(msg))
+					return false
+				}
+			}
+			// "Swallow" the NotFound error since we expected it.
+			a.err = nil
+		}
+	}
+	if exp.Error != "" && a.r != nil {
 		if a.err == nil {
 			a.Fail(gdterrors.UnexpectedError(a.err))
 			a.terminal = true
@@ -127,26 +208,23 @@ func (a *assertions) errorOK() bool {
 			return false
 		}
 	}
+	if a.err != nil {
+		a.Fail(gdterrors.UnexpectedError(a.err))
+		a.terminal = true
+		return false
+	}
 	return true
 }
 
-// unknownOK returns true if the supplied error matches the Unknown condition,
-// false otherwise.
-func (a *assertions) unknownOK() bool {
+func (a *assertions) expectsNotFound() bool {
 	exp := a.exp
-	if exp.Unknown {
-		if !errors.Is(a.err, ErrResourceUnknown) {
-			a.Fail(ResourceUnknown(a.err.Error()))
-		}
-	}
-	return true
+	return (exp.Len != nil && *exp.Len == 0) || exp.NotFound
 }
 
 // notFoundOK returns true if the supplied error and response matches the
 // NotFound condition and the Len==0 condition, false otherwise
 func (a *assertions) notFoundOK() bool {
-	exp := a.exp
-	if (exp.Len != nil && *exp.Len == 0) || exp.NotFound {
+	if a.expectsNotFound() {
 		// First check if the error is like one returned from Get or Delete
 		// that has a 404 ErrStatus.Code in it
 		apierr, ok := a.err.(*apierrors.StatusError)
@@ -156,6 +234,7 @@ func (a *assertions) notFoundOK() bool {
 				a.Fail(ExpectedNotFound(msg))
 				return false
 			}
+			return true
 		}
 		// Next check to see if the supplied resp is a list of objects returned
 		// by the dynamic client and if so, is that an empty list.
@@ -166,20 +245,20 @@ func (a *assertions) notFoundOK() bool {
 				a.Fail(ExpectedNotFound(msg))
 				return false
 			}
+			return true
 		}
 	}
 	return true
 }
 
-// lenOK returns true if the supplied error and subject matches the Len
-// condition, false otherwise
+// lenOK returns true if the subject matches the Len condition, false otherwise
 func (a *assertions) lenOK() bool {
 	exp := a.exp
 	if exp.Len != nil {
 		// if the supplied resp is a list of objects returned by the dynamic
 		// client check its length
 		list, ok := a.r.(*unstructured.UnstructuredList)
-		if ok {
+		if ok && list != nil {
 			if len(list.Items) != *exp.Len {
 				a.Fail(gdterrors.NotEqualLength(*exp.Len, len(list.Items)))
 				return false
@@ -187,6 +266,54 @@ func (a *assertions) lenOK() bool {
 		}
 	}
 	return true
+}
+
+// matchesOK returns true if the subject matches the Matches condition, false
+// otherwise
+func (a *assertions) matchesOK() bool {
+	exp := a.exp
+	if exp.Matches != nil && a.hasSubject() {
+		matchObj := matchObjectFromAny(exp.Matches)
+		res, ok := a.r.(*unstructured.Unstructured)
+		if ok {
+			delta := compareResourceToMatchObject(res, matchObj)
+			if !delta.Empty() {
+				for _, diff := range delta.Differences() {
+					a.Fail(MatchesNotEqual(diff))
+				}
+				return false
+			}
+			return true
+		}
+
+		// TODO(jaypipes): if the supplied resp is a list of objects returned
+		// by the dynamic client check each against the supplied matches
+		// fields.
+		//list, ok := a.r.(*unstructured.UnstructuredList)
+		//if ok {
+		//	for _, obj := range list.Items {
+		//      diff := compareResourceToMatchObject(obj, matchObj)
+		//
+		//		a.Fail(gdterrors.NotEqualLength(*exp.Len, len(list.Items)))
+		//		return false
+		//	}
+		//}
+	}
+	return true
+}
+
+// hasSubject returns true if the assertions `r` field (which contains the
+// subject of which we inspect) is not `nil`.
+func (a *assertions) hasSubject() bool {
+	switch a.r.(type) {
+	case *unstructured.Unstructured:
+		v := a.r.(*unstructured.Unstructured)
+		return v != nil
+	case *unstructured.UnstructuredList:
+		v := a.r.(*unstructured.UnstructuredList)
+		return v != nil
+	}
+	return false
 }
 
 // newAssertions returns an assertions object populated with the supplied http

--- a/compare.go
+++ b/compare.go
@@ -1,0 +1,278 @@
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+
+package kube
+
+import (
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// matchObjectFromAny returns a map[string]interface{} given any of a filepath,
+// an inline YAML string or a map[string]interface{}
+func matchObjectFromAny(m interface{}) map[string]interface{} {
+	switch m.(type) {
+	case string:
+		var err error
+		var b []byte
+		v := m.(string)
+		if probablyFilePath(v) {
+			b, err = ioutil.ReadFile(v)
+			if err != nil {
+				// NOTE(jaypipes): We already validated that the file exists at
+				// parse time. If we get an error here, just panic cuz there's
+				// nothing we can really do.
+				panic(err)
+			}
+		} else {
+			b = []byte(v)
+		}
+		var obj map[string]interface{}
+		if err = yaml.Unmarshal(b, &obj); err != nil {
+			// NOTE(jaypipes): We already validated that the content could be
+			// unmarshaled at parse time. If we get an error here, just panic
+			// cuz there's nothing we can really do.
+			panic(err)
+		}
+		return obj
+	case map[string]interface{}:
+		return m.(map[string]interface{})
+	}
+	return map[string]interface{}{}
+}
+
+type delta struct {
+	differences []string
+}
+
+func (d *delta) Add(diff string) {
+	d.differences = append(d.differences, diff)
+}
+
+func (d *delta) Empty() bool {
+	return len(d.differences) == 0
+}
+
+func (d *delta) Differences() []string {
+	return d.differences
+}
+
+// compareResourceToMatchObject returns a delta object containing and
+// differences between the supplied resource and the match object.
+func compareResourceToMatchObject(
+	res *unstructured.Unstructured,
+	match map[string]interface{},
+) *delta {
+	d := &delta{differences: []string{}}
+	collectFieldDifferences("$", match, res.Object, d)
+	return d
+}
+
+// collectFieldDifferences compares two things and adds any differences between
+// them to a supplied set of differences.
+func collectFieldDifferences(
+	fp string, // the "field path" to the field we are comparing...
+	match interface{},
+	subject interface{},
+	delta *delta,
+) {
+	if !typesComparable(match, subject) {
+		diff := fmt.Sprintf(
+			"%s non-comparable types: %T and %T.",
+			fp, match, subject,
+		)
+		delta.Add(diff)
+	}
+	switch match.(type) {
+	case map[string]interface{}:
+		matchmap := match.(map[string]interface{})
+		subjectmap := subject.(map[string]interface{})
+		for matchk, matchv := range matchmap {
+			subjectv, ok := subjectmap[matchk]
+			newfp := fp + "." + matchk
+			if !ok {
+				diff := fmt.Sprintf("%s not present in subject", newfp)
+				delta.Add(diff)
+			}
+			collectFieldDifferences(newfp, matchv, subjectv, delta)
+		}
+		return
+	case []interface{}:
+		matchlist := match.([]interface{})
+		subjectlist := subject.([]interface{})
+		if len(matchlist) != len(subjectlist) {
+			diff := fmt.Sprintf(
+				"%s had different lengths. expected %d but found %d",
+				fp, len(matchlist), len(subjectlist),
+			)
+			delta.Add(diff)
+		}
+		// Sort order currently matters, unfortunately...
+		for x, matchv := range matchlist {
+			subjectv := subjectlist[x]
+			newfp := fmt.Sprintf("%s[%d]", fp, x)
+			collectFieldDifferences(newfp, matchv, subjectv, delta)
+		}
+		return
+	case int, int8, int16, int32, int64:
+		switch subject.(type) {
+		case int, int8, int16, int32, int64:
+			mv := toInt64(match)
+			sv := toInt64(subject)
+			if mv != sv {
+				diff := fmt.Sprintf(
+					"%s had different values. expected %v but found %v",
+					fp, match, subject,
+				)
+				delta.Add(diff)
+			}
+		case uint, uint8, uint16, uint32, uint64:
+			mv := toUint64(match)
+			sv := toUint64(subject)
+			if mv != sv {
+				diff := fmt.Sprintf(
+					"%s had different values. expected %v but found %v",
+					fp, match, subject,
+				)
+				delta.Add(diff)
+			}
+		case string:
+			mv := toInt64(match)
+			ss := subject.(string)
+			sv, err := strconv.Atoi(ss)
+			if err != nil {
+				diff := fmt.Sprintf(
+					"%s had different values. expected %v but found %v",
+					fp, match, subject,
+				)
+				delta.Add(diff)
+				return
+			}
+			if mv != int64(sv) {
+				diff := fmt.Sprintf(
+					"%s had different values. expected %v but found %v",
+					fp, match, subject,
+				)
+				delta.Add(diff)
+			}
+		}
+		return
+	case string:
+		switch subject.(type) {
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64:
+			mv := match.(string)
+			si := subject.(int)
+			sv := strconv.Itoa(si)
+			if mv != sv {
+				diff := fmt.Sprintf(
+					"%s had different values. expected %v but found %v",
+					fp, match, subject,
+				)
+				delta.Add(diff)
+			}
+		case string:
+			mv, _ := match.(string)
+			sv, _ := subject.(string)
+			if mv != sv {
+				diff := fmt.Sprintf(
+					"%s had different values. expected %v but found %v",
+					fp, match, subject,
+				)
+				delta.Add(diff)
+			}
+		}
+		return
+	}
+	if !reflect.DeepEqual(match, subject) {
+		diff := fmt.Sprintf(
+			"%s had different values. expected %v but found %v",
+			fp, match, subject,
+		)
+		delta.Add(diff)
+	}
+}
+
+// typesComparable returns true if the two supplied things are comparable,
+// false otherwise
+func typesComparable(a, b interface{}) bool {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+	at := av.Kind()
+	bt := bv.Kind()
+	switch at {
+	case reflect.Int, reflect.Int8, reflect.Int32, reflect.Int64:
+		switch bt {
+		case reflect.Int, reflect.Int8, reflect.Int32, reflect.Int64,
+			reflect.String:
+			return true
+		default:
+			return false
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint32, reflect.Uint64:
+		switch bt {
+		case reflect.Uint, reflect.Uint8, reflect.Uint32,
+			reflect.Uint64, reflect.String:
+			return true
+		default:
+			return false
+		}
+	case reflect.Complex64, reflect.Complex128:
+		switch bt {
+		case reflect.Complex64, reflect.Complex128, reflect.String:
+			return true
+		default:
+			return false
+		}
+	case reflect.String:
+		switch bt {
+		case reflect.Int, reflect.Int8, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint32, reflect.Uint64,
+			reflect.Complex64, reflect.Complex128, reflect.String:
+			return true
+		default:
+			return false
+		}
+	}
+	return reflect.TypeOf(a) == reflect.TypeOf(b)
+}
+
+// toUint64 takes an interface and returns a uint64
+func toUint64(v interface{}) uint64 {
+	switch v.(type) {
+	case uint64:
+		return v.(uint64)
+	case uint8:
+		return uint64(v.(uint8))
+	case uint16:
+		return uint64(v.(uint16))
+	case uint32:
+		return uint64(v.(uint32))
+	case uint:
+		return uint64(v.(uint))
+	}
+	return 0
+}
+
+// toInt64 takes an interface and returns an int64
+func toInt64(v interface{}) int64 {
+	switch v.(type) {
+	case int64:
+		return v.(int64)
+	case int8:
+		return int64(v.(int8))
+	case int16:
+		return int64(v.(int16))
+	case int32:
+		return int64(v.(int32))
+	case int:
+		return int64(v.(int))
+	}
+	return 0
+}

--- a/connect.go
+++ b/connect.go
@@ -6,14 +6,18 @@ package kube
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	gdtcontext "github.com/jaypipes/gdt-core/context"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+	discocached "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -86,55 +90,66 @@ func (s *Spec) Config(ctx context.Context) (*rest.Config, error) {
 	).ClientConfig()
 }
 
+type groupVersion struct {
+	group   string
+	version string
+}
+
 // connection is a struct containing a discovery client and a dynamic client
 // that the Spec uses to communicate with Kubernetes.
 type connection struct {
-	disco  discovery.DiscoveryInterface
+	mapper meta.RESTMapper
+	disco  discovery.CachedDiscoveryInterface
 	client dynamic.Interface
-	// preferredVersions is a map, keyed by APIGroup, of the preferred
-	// APIVersion for that group. When resources are not specified with a
-	// version (or a group version), we use this as a lookup.
-	preferredVersions map[string]string
+	// resourceInfo is a map, keyed by lowercase resource Kind, Plural Kind or
+	// shortname/alias, of the APIResource with the Group and Version set
+	// properly to theAPIGroup and preferred APIVersion for that group. When
+	// resources are not specified with a version (or a group version), we use
+	// this as a lookup.
+	resourceLookup map[string]*metav1.APIResource
 }
 
-// apiResourceFromGVK returns the metav1.APIResource (which is basically the
-// GVK with the plural form of the Kind and some metadata about whether the
-// resource is namespace scoped, etc) corresponding to the supplied
-// GroupVersionKind. If no match could be made, returns
-// ErrRuntimeResourceUnknown.
-func (c *connection) apiResourceFromGVK(
-	gvk schema.GroupVersionKind,
-) (metav1.APIResource, error) {
-	empty := metav1.APIResource{}
-	var pv string
-	var pvFound bool
-	if gvk.Version == "" {
-		pv, pvFound = c.preferredVersions[gvk.Group]
-		if !pvFound {
-			return empty, ResourceUnknown(gvk.Kind)
-		}
-		gvk.Version = pv
+// mappingFor returns a RESTMapper for a given resource type or kind
+func (c *connection) mappingFor(typeOrKind string) (*meta.RESTMapping, error) {
+	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(typeOrKind)
+	gvk := schema.GroupVersionKind{}
+
+	if fullySpecifiedGVR != nil {
+		gvk, _ = c.mapper.KindFor(*fullySpecifiedGVR)
 	}
-	resources, err := c.disco.ServerResourcesForGroupVersion(
-		gvk.GroupVersion().String(),
-	)
+	if gvk.Empty() {
+		gvk, _ = c.mapper.KindFor(groupResource.WithVersion(""))
+	}
+	if !gvk.Empty() {
+		return c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+
+	fullySpecifiedGVK, groupKind := schema.ParseKindArg(typeOrKind)
+	if fullySpecifiedGVK == nil {
+		gvk := groupKind.WithVersion("")
+		fullySpecifiedGVK = &gvk
+	}
+
+	if !fullySpecifiedGVK.Empty() {
+		if mapping, err := c.mapper.RESTMapping(fullySpecifiedGVK.GroupKind(), fullySpecifiedGVK.Version); err == nil {
+			return mapping, nil
+		}
+	}
+
+	mapping, err := c.mapper.RESTMapping(groupKind, gvk.Version)
 	if err != nil {
-		return empty, ResourceUnknown(gvk.Kind)
-	}
-
-	for _, r := range resources.APIResources {
-		if strings.EqualFold(r.Kind, gvk.Kind) || strings.EqualFold(r.Name, gvk.Kind) {
-			// NOTE(jaypipes): This is crazy that we need to do this, but
-			// APIResource objects in the ServerResourcesForGroupVersion don't
-			// necessarily have their Version fields set.
-			if r.Version == "" {
-				r.Version = pv
-			}
-			return r, nil
+		// if we error out here, it is because we could not match a resource or a kind
+		// for the given argument. To maintain consistency with previous behavior,
+		// announce that a resource type could not be found.
+		// if the error is _not_ a *meta.NoKindMatchError, then we had trouble doing discovery,
+		// so we should return the original error since it may help a user diagnose what is actually wrong
+		if meta.IsNoMatchError(err) {
+			return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
 		}
+		return nil, err
 	}
 
-	return empty, ResourceUnknown(gvk.Kind)
+	return mapping, nil
 }
 
 // gvrFromGVK returns a GroupVersionResource from a GroupVersionKind, using the
@@ -146,22 +161,12 @@ func (c *connection) gvrFromGVK(
 	gvk schema.GroupVersionKind,
 ) (schema.GroupVersionResource, error) {
 	empty := schema.GroupVersionResource{}
-	ar, err := c.apiResourceFromGVK(gvk)
+	r, err := c.mappingFor(gvk.Kind)
 	if err != nil {
-		return empty, nil
+		return empty, ResourceUnknown(gvk)
 	}
-	gvr := schema.GroupVersionResource{
-		Group:    ar.Group,
-		Version:  ar.Version,
-		Resource: ar.Name,
-	}
-	if gvr.Group == "" {
-		gvr.Group = gvk.Group
-	}
-	if gvr.Version == "" {
-		gvr.Version = gvk.Version
-	}
-	return gvr, nil
+
+	return r.Resource, nil
 }
 
 // connect returns a connection with a discovery client and a Kubernetes
@@ -176,22 +181,59 @@ func (s *Spec) connect(ctx context.Context) (*connection, error) {
 	if err != nil {
 		return nil, err
 	}
-	disco, err := discovery.NewDiscoveryClientForConfig(cfg)
+	discoverer, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
-	apiGroups, err := disco.ServerGroups()
+	disco := discocached.NewMemCacheClient(discoverer)
+	apiGroups, resourceLists, err := disco.ServerGroupsAndResources()
 	if err != nil {
 		return nil, err
 	}
-	prefVersions := map[string]string{}
-	for _, apiGroup := range apiGroups.Groups {
-		prefVersions[apiGroup.Name] = apiGroup.PreferredVersion.Version
+	preferredVersions := map[string]string{}
+	for _, apiGroup := range apiGroups {
+		preferredVersions[apiGroup.Name] = apiGroup.PreferredVersion.Version
 	}
+	resLookup := map[string]*metav1.APIResource{}
+	for _, resList := range resourceLists {
+		gvParts := strings.SplitN(resList.GroupVersion, "/", 1)
+		g := gvParts[0]
+		if len(gvParts) == 1 {
+			g = ""
+		}
+		pv := preferredVersions[g]
+		for _, res := range resList.APIResources {
+			// Some APIResources, e.g. deployment/status, have a slash in their
+			// Name but their Kind overlaps the full resource, so we skip
+			// these...
+			if strings.ContainsRune(res.Name, '/') {
+				continue
+			}
+			r := &metav1.APIResource{
+				Name:               res.Name,
+				SingularName:       res.SingularName,
+				Group:              g,
+				Version:            pv,
+				Kind:               res.Kind,
+				Verbs:              res.Verbs,
+				ShortNames:         res.ShortNames,
+				Categories:         res.Categories,
+				StorageVersionHash: res.StorageVersionHash,
+			}
+			resLookup[strings.ToLower(res.Name)] = r
+			resLookup[strings.ToLower(res.Kind)] = r
+			for _, alias := range res.ShortNames {
+				resLookup[strings.ToLower(alias)] = r
+			}
+		}
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(disco)
+	expander := restmapper.NewShortcutExpander(mapper, disco)
 
 	return &connection{
-		disco:             disco,
-		client:            c,
-		preferredVersions: prefVersions,
+		mapper:         expander,
+		disco:          disco,
+		client:         c,
+		resourceLookup: resLookup,
 	}, nil
 }

--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	gdterrors "github.com/jaypipes/gdt-core/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (
@@ -55,6 +56,12 @@ var (
 		"%w: invalid resource specifier or filepath",
 		gdterrors.ErrInvalid,
 	)
+	// ErrMatchesInvalid is returned when the `Kube.Assert.Matches` value is
+	// malformed.
+	ErrMatchesInvalid = fmt.Errorf(
+		"%w: `kube.assert.matches` not well-formed",
+		gdterrors.ErrInvalid,
+	)
 	// ErrResourceUnknown is returned when an unknown resource kind is
 	// specified for a create/apply/delete target. This is a runtime error
 	// because we rely on the discovery client to determine whether a resource
@@ -68,6 +75,12 @@ var (
 	// not find that.
 	ErrExpectedNotFound = fmt.Errorf(
 		"%w: expected not found",
+		gdterrors.ErrFailure,
+	)
+	// ErrMatchesNotEqual is returned when we failed to match a resource to an
+	// object field in a `kube.assert.matches` object.
+	ErrMatchesNotEqual = fmt.Errorf(
+		"%w: match field not equal",
 		gdterrors.ErrFailure,
 	)
 )
@@ -90,12 +103,33 @@ func InvalidResourceSpecifierOrFilepath(subject string) error {
 }
 
 // ResourceUnknown returns ErrRuntimeResourceUnknown for a given kind
-func ResourceUnknown(kind string) error {
-	return fmt.Errorf("%w: %s", ErrResourceUnknown, kind)
+func ResourceUnknown(gvk schema.GroupVersionKind) error {
+	return fmt.Errorf("%w: %s", ErrResourceUnknown, gvk)
 }
 
 // ExpectedNotFound returns ErrExpectedNotFound for a given status code or
 // number of items.
 func ExpectedNotFound(msg string) error {
 	return fmt.Errorf("%w: %s", ErrExpectedNotFound, msg)
+}
+
+// MatchesInvalid returns ErrMatchesInvalid when a `kube.assert.matches` field
+// is not well-formed.
+func MatchesInvalid(matches interface{}) error {
+	return fmt.Errorf(
+		"%w: need string or map[string]interface{} but got %T",
+		ErrMatchesInvalid, matches,
+	)
+}
+
+// MatchesInvalidUnmarshalError returns ErrMatchesInvalid when a `kube.assert.matches` field
+// contains invalid YAML content.
+func MatchesInvalidUnmarshalError(err error) error {
+	return fmt.Errorf("%w: %s", ErrMatchesInvalid, err)
+}
+
+// MatchesNotEqual returns ErrMatchesNotEqual when a `kube.assert.matches` object
+// did not match the returned resource.
+func MatchesNotEqual(msg string) error {
+	return fmt.Errorf("%w: %s", ErrMatchesNotEqual, msg)
 }

--- a/parse.go
+++ b/parse.go
@@ -165,6 +165,14 @@ func validateKubeSpec(s *Spec) error {
 			return err
 		}
 	}
+	if s.Kube.Assert != nil {
+		exp := s.Kube.Assert
+		if exp.Matches != nil {
+			if err := validateMatches(exp.Matches); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -210,6 +218,57 @@ func validateResourceIdentifier(subject string) error {
 	}
 	if strings.Count(subject, "/") > 1 {
 		return InvalidResourceSpecifier(subject)
+	}
+	return nil
+}
+
+// resourceTypeAndNameFromIdentifier returns a resource type, which is the
+// shortname, singular or plural of a resource kind, (e.g. "po", "pods" or
+// "pod") and a resource name. The resource name may be empty, in which case
+// the resource identifier refers to a collection of resources.
+//
+// The following formats for a resource identifier string are allowed:
+//
+// * "pods" - pluralized resource type, refers to a collection of Pod resources
+// * "po" - shortname of a resource type, refers to a collection of Pod
+//   resources
+// * "pod" - singular of a resource type, refers to a collection of Pod
+//   resources (because no resource name has been specified)
+// * "pods/my-pod" - pluralized resource type along with a resource name,
+//   refers to a single Pod resource with the name "my-pod"
+// * "pod/my-pod" - singular resource type along with a resource name,
+//   refers to a single Pod resource with the name "my-pod"
+// * "po/my-pod" - shortname of a resource type along with a resource name,
+//   refers to a single Pod resource with the name "my-pod"
+func resourceTypeAndNameFromIdentifier(identifier string) (string, string) {
+	rt := ""
+	rn := ""
+
+	return rt, rn
+}
+
+// validateMatches checks what the test author placed in the `Kube.Matches`
+// field to see if it contains one of:
+// * file path (and checks existence of this file)
+// * inline YAML (and checks that can be unmarshaled)
+// * map[string]interface{}
+func validateMatches(matches interface{}) error {
+	switch matches.(type) {
+	case string:
+		v := matches.(string)
+		if probablyFilePath(v) {
+			return validateFileExists(v)
+		}
+		// inline YAML. Let's quickly check it can be unmarshaled into a
+		// map[string]interface{}
+		var m map[string]interface{}
+		if err := yaml.Unmarshal([]byte(v), &m); err != nil {
+			return MatchesInvalidUnmarshalError(err)
+		}
+	case map[string]interface{}:
+		return nil
+	default:
+		return MatchesInvalid(matches)
 	}
 	return nil
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -243,6 +243,69 @@ func TestDeleteFileNotFound(t *testing.T) {
 	require.Nil(s)
 }
 
+func TestFailureBadMatchesFileNotFound(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "failures", "bad-matches-file-not-found.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+		scenario.WithContext(ctx),
+	)
+	assert.NotNil(err)
+	assert.ErrorIs(err, errors.ErrInvalidFileNotFound)
+	assert.Nil(s)
+}
+
+func TestFailureBadMatchesInvalidYAML(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "failures", "bad-matches-invalid-yaml.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+		scenario.WithContext(ctx),
+	)
+	assert.NotNil(err)
+	assert.ErrorIs(err, gdtkube.ErrMatchesInvalid)
+	assert.Nil(s)
+}
+
+func TestFailureBadMatchesNotMapAny(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "failures", "bad-matches-not-map-any.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+		scenario.WithContext(ctx),
+	)
+	assert.NotNil(err)
+	assert.ErrorIs(err, gdtkube.ErrMatchesInvalid)
+	assert.Nil(s)
+}
+
 func TestParse(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/run.go
+++ b/run.go
@@ -259,9 +259,7 @@ func (s *Spec) runDelete(
 
 	kind, name := splitKindName(s.Kube.Delete)
 	gvk := schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    kind,
+		Kind: kind,
 	}
 	res, err := c.gvrFromGVK(gvk)
 	a := newAssertions(s.Kube.Assert, err, nil)

--- a/run_test.go
+++ b/run_test.go
@@ -242,6 +242,32 @@ func TestPodCreateGetDelete(t *testing.T) {
 	require.Nil(err, "%s", err)
 }
 
+func TestMatches(t *testing.T) {
+	skipIfKind(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "matches.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	kfix := kindfix.New()
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
+	ctx = gdtcontext.RegisterFixture(ctx, "kind", kfix)
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+		scenario.WithContext(ctx),
+	)
+	require.Nil(err)
+	require.NotNil(s)
+
+	err = s.Run(ctx, t)
+	require.Nil(err, "%s", err)
+}
+
 func skipIfKind(t *testing.T) {
 	_, found := os.LookupEnv("SKIP_KIND")
 	if found {

--- a/testdata/create-get-delete-pod.yaml
+++ b/testdata/create-get-delete-pod.yaml
@@ -12,9 +12,9 @@ tests:
   - name: delete-pod
     kube:
       delete: pods/nginx
-  # TODO(jaypipes): remove this when waiters/retries are implemented.
-  - name: sleep-a-bit
-    exec: sleep 10
+  # TODO(jaypipes): refactor this when retries are implemented.
+    wait:
+      after: 3s
   - name: pod-no-longer-exists
     kube:
       get: pods/nginx

--- a/testdata/create-unknown-resource.yaml
+++ b/testdata/create-unknown-resource.yaml
@@ -10,4 +10,4 @@ tests:
        metadata:
          name: unknown
      assert:
-       notfound: true
+       unknown: true

--- a/testdata/delete-unknown-resource.yaml
+++ b/testdata/delete-unknown-resource.yaml
@@ -6,4 +6,4 @@ tests:
  - kube:
      delete: unknown/unknown
      assert:
-       notfound: true
+       unknown: true

--- a/testdata/failures/bad-matches-file-not-found.yaml
+++ b/testdata/failures/bad-matches-file-not-found.yaml
@@ -1,0 +1,7 @@
+name: bad-matches-file-not-found
+description: matches refers to unknown file
+tests:
+ - kube:
+     get: pods/mypod
+     assert:
+       matches: does/not/exist.yaml

--- a/testdata/failures/bad-matches-invalid-yaml.yaml
+++ b/testdata/failures/bad-matches-invalid-yaml.yaml
@@ -1,0 +1,7 @@
+name: bad-matches-invalid-yaml
+description: matches contains invalid YAML
+tests:
+ - kube:
+     get: pods/mypod
+     assert:
+       matches: :this-is-not-valid!YAML

--- a/testdata/failures/bad-matches-not-map-any.yaml
+++ b/testdata/failures/bad-matches-not-map-any.yaml
@@ -1,0 +1,7 @@
+name: bad-matches-not-map-any
+description: "matches is not a string or map[string]interface{}"
+tests:
+ - kube:
+     get: pods/mypod
+     assert:
+       matches: 42

--- a/testdata/manifests/nginx-deployment.yaml
+++ b/testdata/manifests/nginx-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/testdata/matches.yaml
+++ b/testdata/matches.yaml
@@ -1,0 +1,27 @@
+name: matches
+description: create a deployment and check the matches condition succeeds
+require:
+  - kind
+tests:
+  - name: create-deployment
+    kube:
+      create: testdata/manifests/nginx-deployment.yaml
+    wait:
+      # TODO(jaypipes): Remove after retries implemented
+      after: 10s
+  - name: deployment-exists
+    kube:
+      get: deployments/nginx
+      assert:
+        matches:
+          spec:
+            replicas: 2
+            template:
+              metadata:
+                labels:
+                  app: nginx
+          status:
+            readyReplicas: 2
+  - name: delete-deployment
+    kube:
+      delete: deployments/nginx


### PR DESCRIPTION
Adds the ability to specify a match resource or set of fields to compare against the result from a `kube.get` call.

Matches is either a string or a map[string]interface{} containing the resource that the `Kube.Get` should match against. If Matches is a string, the string can be either a file path to a YAML manifest or inline an YAML string containing the resource fields to compare.

Only fields present in the Matches resource are compared. There is a check for existence in the retrieved resource as well as a check that the value of the fields match. Only scalar fields are matched entirely. In other words, you do not need to specify every field of a struct field in order to compare the value of a single field in the nested struct.

As an example, imagine you wanted to check that a Deployment resource's `Status.ReadyReplicas` field was 2. You do not need to specify all other `Deployment.Status` fields like `Status.Replicas` in order to match the `Status.ReadyReplicas` field value. You only need to include the `Status.ReadyReplicas` field in the `Matches` value as these examples demonstrate:

```yaml
tests:
 - name: check deployment's ready replicas is 2
   kube:
     get: deployments/my-deployment
     assert:
       matches: |
         kind: Deployment
         metadata:
           name: my-deployment
         status:
           readyReplicas: 2
```

you don't even need to include the kind and metadata in `Matches`. If missing, no kind and name matching will be performed.

```yaml
tests:
 - name: check deployment's ready replicas is 2
   kube:
     get: deployments/my-deployment
     assert:
       matches: |
         status:
           readyReplicas: 2
```

In fact, you don't need to use an inline multiline YAML string. You can use a `map[string]interface{}` as well:

```yaml
tests:
 - name: check deployment's ready replicas is 2
   kube:
     get: deployments/my-deployment
     assert:
       matches:
         status:
           readyReplicas: 2
```