### PR TITLE
implement retries for `kube.get` assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,105 @@ tests:
            readyReplicas: 2
 ```
 
+### Timeouts and retrying `kube.get` assertions
+
+When evaluating `kube.assert.matches` conditions for `kube.get`, `gdt` inspects
+the test's `timeout.after` value to determine how long to retry the `get` call
+and recheck the assertions. If `timeout.after` is empty, `gdt` uses a **default
+timeout of 5 seconds**.
+
+If you're interested in seeing the individual results of `gdt`'s
+assertion-checks for a single `get` call, you can use the `gdt.WithDebug()`
+function, like this test function demonstrates:
+
+file: `testdata/matches.yaml`:
+
+```yaml
+name: matches
+description: create a deployment and check the matches condition succeeds
+require:
+  - kind
+tests:
+  - name: create-deployment
+    kube:
+      create: testdata/manifests/nginx-deployment.yaml
+  - name: deployment-exists
+    kube:
+      get: deployments/nginx
+      assert:
+        matches:
+          spec:
+            replicas: 2
+            template:
+              metadata:
+                labels:
+                  app: nginx
+          status:
+            readyReplicas: 2
+  - name: delete-deployment
+    kube:
+      delete: deployments/nginx
+```
+
+file: `matches_test.go`
+
+```go
+import (
+    "github.com/jaypipes/gdt"
+    . "github.com/jaypipes/gdt-kube"
+    kindfix "github.com/jaypipes/gdt-kube/fixture/kind"
+)
+
+func TestMatches(t *testing.T) {
+	fp := filepath.Join("testdata", "matches.yaml")
+
+	kfix := kindfix.New()
+
+	s, err := gdt.From(fp)
+
+	ctx := gdt.NewContext(gdt.WithDebug(os.Stdout))
+	ctx = gdt.RegisterFixture(ctx, "kind", kfix)
+	s.Run(ctx, t)
+}
+```
+
+Here's what running `go test -v matches_test.go` would look like:
+
+```
+$ go test -v matches_test.go
+=== RUN   TestMatches
+=== RUN   TestMatches/matches
+=== RUN   TestMatches/matches/create-deployment
+=== RUN   TestMatches/matches/deployment-exists
+deployment-exists (try 1 after 1.303µs) ok: false, terminal: false
+deployment-exists (try 1 after 1.303µs) failure: assertion failed: match field not equal: $.status.readyReplicas not present in subject
+deployment-exists (try 2 after 595.62786ms) ok: false, terminal: false
+deployment-exists (try 2 after 595.62786ms) failure: assertion failed: match field not equal: $.status.readyReplicas not present in subject
+deployment-exists (try 3 after 1.020003807s) ok: false, terminal: false
+deployment-exists (try 3 after 1.020003807s) failure: assertion failed: match field not equal: $.status.readyReplicas not present in subject
+deployment-exists (try 4 after 1.760006109s) ok: false, terminal: false
+deployment-exists (try 4 after 1.760006109s) failure: assertion failed: match field not equal: $.status.readyReplicas had different values. expected 2 but found 1
+deployment-exists (try 5 after 2.772416449s) ok: true, terminal: false
+=== RUN   TestMatches/matches/delete-deployment
+--- PASS: TestMatches (3.32s)
+    --- PASS: TestMatches/matches (3.30s)
+        --- PASS: TestMatches/matches/create-deployment (0.01s)
+        --- PASS: TestMatches/matches/deployment-exists (2.78s)
+        --- PASS: TestMatches/matches/delete-deployment (0.02s)
+PASS
+ok  	command-line-arguments	3.683s
+```
+
+You can see from the debug output above that `gdt` created the Deployment and
+then did a `kube.get` for the `deployments/nginx` Deployment. Initially
+(attempt 1), the `kube.assert.matches` assertion failed because the
+`status.readyReplicas` field was not present in the returned resource. `gdt`
+retried the `kube.get` call 4 more times (attempts 2-5), with attempts 2 and 3
+failed the existence check for the `status.readyReplicas` field and attempt 4
+failing the *value* check for the `status.readyReplicas` field being `1`
+instead of the expected `2`. Finally, when the Deployment was completely rolled
+out, attempt 5 succeeded in all the `kube.assert.matches` assertions.
+
 ## Determining Kubernetes config, context and namespace values
 
 When evaluating how to construct a Kubernetes client `gdt-kube` uses the following

--- a/compare.go
+++ b/compare.go
@@ -88,6 +88,7 @@ func collectFieldDifferences(
 			fp, match, subject,
 		)
 		delta.Add(diff)
+		return
 	}
 	switch match.(type) {
 	case map[string]interface{}:
@@ -99,6 +100,7 @@ func collectFieldDifferences(
 			if !ok {
 				diff := fmt.Sprintf("%s not present in subject", newfp)
 				delta.Add(diff)
+				continue
 			}
 			collectFieldDifferences(newfp, matchv, subjectv, delta)
 		}
@@ -112,6 +114,7 @@ func collectFieldDifferences(
 				fp, len(matchlist), len(subjectlist),
 			)
 			delta.Add(diff)
+			return
 		}
 		// Sort order currently matters, unfortunately...
 		for x, matchv := range matchlist {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jaypipes/gdt-kube
 go 1.19
 
 require (
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/jaypipes/gdt v1.9.0
 	github.com/jaypipes/gdt-core v1.9.3
 	github.com/samber/lo v1.38.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -55,6 +57,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/run.go
+++ b/run.go
@@ -12,12 +12,22 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
+	backoff "github.com/cenkalti/backoff/v4"
+	"github.com/jaypipes/gdt-core/debug"
 	"github.com/jaypipes/gdt-core/result"
+	gdttypes "github.com/jaypipes/gdt-core/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+const (
+	// defaultGetTimeout is used as a retry max time if the spec's Timeout has
+	// not been specified.
+	defaultGetTimeout = time.Second * 5
 )
 
 // Run executes the test described by the Kubernetes test. A new Kubernetes
@@ -63,10 +73,54 @@ func (s *Spec) runGet(
 		}
 		return nil
 	}
-	if name == "" {
-		return s.doList(ctx, t, c, res, s.Namespace())
+
+	// if the Spec has no timeout, default it to a reasonable value
+	var cancel context.CancelFunc
+	_, hasDeadline := ctx.Deadline()
+	if !hasDeadline {
+		ctx, cancel = context.WithTimeout(ctx, defaultGetTimeout)
+		defer cancel()
 	}
-	return s.doGet(ctx, t, c, res, name, s.Namespace())
+
+	// retry the Get/List and test the assertions until they succeed, there is
+	// a terminal failure, or the timeout expires.
+	bo := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	ticker := backoff.NewTicker(bo)
+	attempts := 0
+	success := false
+	start := time.Now().UTC()
+	for tick := range ticker.C {
+		attempts++
+		after := tick.Sub(start)
+
+		if name == "" {
+			a = s.doList(ctx, t, c, res, s.Namespace())
+		} else {
+			a = s.doGet(ctx, t, c, res, name, s.Namespace())
+		}
+		success := a.OK()
+		term := a.Terminal()
+		debug.Println(
+			ctx, "%s (try %d after %s) ok: %v, terminal: %v",
+			s.Title(), attempts, after, success, term,
+		)
+		if success || term {
+			ticker.Stop()
+			break
+		}
+		for _, f := range a.Failures() {
+			debug.Println(
+				ctx, "%s (try %d after %s) failure: %s",
+				s.Title(), attempts, after, f,
+			)
+		}
+	}
+	if !success {
+		for _, f := range a.Failures() {
+			t.Error(f)
+		}
+	}
+	return nil
 }
 
 // doList performs the List() call and assertion check for a supplied resource
@@ -77,18 +131,12 @@ func (s *Spec) doList(
 	c *connection,
 	res schema.GroupVersionResource,
 	namespace string,
-) error {
+) gdttypes.Assertions {
 	list, err := c.client.Resource(res).Namespace(namespace).List(
 		ctx,
 		metav1.ListOptions{},
 	)
-	a := newAssertions(s.Kube.Assert, err, list)
-	if !a.OK() {
-		for _, f := range a.Failures() {
-			t.Error(f)
-		}
-	}
-	return nil
+	return newAssertions(s.Kube.Assert, err, list)
 }
 
 // doGet performs the Get() call and assertion check for a supplied resource
@@ -100,19 +148,13 @@ func (s *Spec) doGet(
 	res schema.GroupVersionResource,
 	name string,
 	namespace string,
-) error {
+) gdttypes.Assertions {
 	obj, err := c.client.Resource(res).Namespace(namespace).Get(
 		ctx,
 		name,
 		metav1.GetOptions{},
 	)
-	a := newAssertions(s.Kube.Assert, err, obj)
-	if !a.OK() {
-		for _, f := range a.Failures() {
-			t.Error(f)
-		}
-	}
-	return nil
+	return newAssertions(s.Kube.Assert, err, obj)
 }
 
 // splitKindName returns the Kind for a supplied `Get` or `Delete` command

--- a/run_test.go
+++ b/run_test.go
@@ -252,7 +252,7 @@ func TestMatches(t *testing.T) {
 
 	kfix := kindfix.New()
 
-	ctx := gdtcontext.New()
+	ctx := gdtcontext.New(gdtcontext.WithDebug(os.Stdout))
 	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
 	ctx = gdtcontext.RegisterFixture(ctx, "kind", kfix)
 

--- a/testdata/create-get-delete-pod.yaml
+++ b/testdata/create-get-delete-pod.yaml
@@ -12,9 +12,6 @@ tests:
   - name: delete-pod
     kube:
       delete: pods/nginx
-  # TODO(jaypipes): refactor this when retries are implemented.
-    wait:
-      after: 3s
   - name: pod-no-longer-exists
     kube:
       get: pods/nginx

--- a/testdata/matches.yaml
+++ b/testdata/matches.yaml
@@ -6,10 +6,9 @@ tests:
   - name: create-deployment
     kube:
       create: testdata/manifests/nginx-deployment.yaml
-    wait:
-      # TODO(jaypipes): Remove after retries implemented
-      after: 10s
   - name: deployment-exists
+    timeout:
+      after: 20s
     kube:
       get: deployments/nginx
       assert:


### PR DESCRIPTION
When evaluating `kube.assert.matches` conditions for `kube.get`, `gdt` inspects the test's `timeout.after` value to determine how long to retry the `get` call and recheck the assertions. If `timeout.after` is empty, `gdt` uses a **default timeout of 5 seconds**.

If you're interested in seeing the individual results of `gdt`'s assertion-checks for a single `get` call, you can use the `gdt.WithDebug()` function, like this test function demonstrates:

file: `testdata/matches.yaml`:

```yaml
name: matches
description: create a deployment and check the matches condition succeeds
require:
  - kind
tests:
  - name: create-deployment
    kube:
      create: testdata/manifests/nginx-deployment.yaml
  - name: deployment-exists
    kube:
      get: deployments/nginx
      assert:
        matches:
          spec:
            replicas: 2
            template:
              metadata:
                labels:
                  app: nginx
          status:
            readyReplicas: 2
  - name: delete-deployment
    kube:
      delete: deployments/nginx
```

file: `matches_test.go`

```go
import (
    "github.com/jaypipes/gdt"
    . "github.com/jaypipes/gdt-kube"
    kindfix "github.com/jaypipes/gdt-kube/fixture/kind"
)

func TestMatches(t *testing.T) {
	fp := filepath.Join("testdata", "matches.yaml")

	kfix := kindfix.New()

	s, err := gdt.From(fp)

	ctx := gdt.NewContext(gdt.WithDebug(os.Stdout))
	ctx = gdt.RegisterFixture(ctx, "kind", kfix)
	s.Run(ctx, t)
}
```

Here's what running `go test -v matches_test.go` would look like:

```
$ go test -v matches_test.go
=== RUN   TestMatches
=== RUN   TestMatches/matches
=== RUN   TestMatches/matches/create-deployment
=== RUN   TestMatches/matches/deployment-exists
deployment-exists (try 1 after 1.303µs) ok: false, terminal: false
deployment-exists (try 1 after 1.303µs) failure: assertion failed: match field not equal: $.status.readyReplicas not present in subject
deployment-exists (try 2 after 595.62786ms) ok: false, terminal: false
deployment-exists (try 2 after 595.62786ms) failure: assertion failed: match field not equal: $.status.readyReplicas not present in subject
deployment-exists (try 3 after 1.020003807s) ok: false, terminal: false
deployment-exists (try 3 after 1.020003807s) failure: assertion failed: match field not equal: $.status.readyReplicas not present in subject
deployment-exists (try 4 after 1.760006109s) ok: false, terminal: false
deployment-exists (try 4 after 1.760006109s) failure: assertion failed: match field not equal: $.status.readyReplicas had different values. expected 2 but found 1
deployment-exists (try 5 after 2.772416449s) ok: true, terminal: false
=== RUN   TestMatches/matches/delete-deployment
--- PASS: TestMatches (3.32s)
    --- PASS: TestMatches/matches (3.30s)
        --- PASS: TestMatches/matches/create-deployment (0.01s)
        --- PASS: TestMatches/matches/deployment-exists (2.78s)
        --- PASS: TestMatches/matches/delete-deployment (0.02s)
PASS
ok  	command-line-arguments	3.683s
```

You can see from the debug output above that `gdt` created the Deployment and then did a `kube.get` for the `deployments/nginx` Deployment. Initially (attempt 1), the `kube.assert.matches` assertion failed because the `status.readyReplicas` field was not present in the returned resource. `gdt` retried the `kube.get` call 4 more times (attempts 2-5), with attempts 2 and 3 failed the existence check for the `status.readyReplicas` field and attempt 4 failing the *value* check for the `status.readyReplicas` field being `1` instead of the expected `2`. Finally, when the Deployment was completely rolled out, attempt 5 succeeded in all the `kube.assert.matches` assertions.