### PR TITLE
support `kube.apply`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ matches some expectation:
   that will be read from the Kubernetes API server.
 * `kube.create`: (optional) string containing either a file path to a YAML
   manifest or a string of raw YAML containing the resource(s) to create.
+* `kube.apply`: (optional) string containing either a file path to a YAML
+  manifest or a string of raw YAML containing the resource(s) for which
+  `gdt-kube` will perform a Kubernetes Apply call.
 * `kube.delete`: (optional) string containing either a resource specifier (e.g.
   `pods`, `po/nginx` or a file path to a YAML manifest containing resources
   that will be deleted.
@@ -239,9 +242,12 @@ tests:
   - kube.delete: pods/nginx
 ```
 
+### Executing arbitrary commands or shell scripts
+
 You can mix other `gdt` test types in a single `gdt` test scenario. For
-example, here we are testing the creation of a Pod, waiting a little while,
-then using the `gdt` `exec` test type to test SSH connectivity to the Pod.
+example, here we are testing the creation of a Pod, waiting a little while with
+the `wait.after` directive, then using the `gdt` `exec` test type to test SSH
+connectivity to the Pod.
 
 ```yaml
 name: create-check-ssh
@@ -250,9 +256,12 @@ require:
   - kind
 tests:
   - kube.create: manifests/deployment.yaml
-  - exec: sleep 30
+    wait:
+      after: 30s
   - exec: ssh -T someuser@ip
 ```
+
+### Asserting resource fields using `kube.assert.matches`
 
 A test that checks that a Deployment resource's `Status.ReadyReplicas` field
 is `2`. You do not need to specify all other `Deployment.Status` fields like
@@ -300,6 +309,79 @@ tests:
        matches:
          status:
            readyReplicas: 2
+```
+
+### Updating a resource and asserting corresponding field changes
+
+Here is an example of creating a Deployment with an initial `spec.replicas`
+count of 2, then applying a change to `spec.replicas` of 1, then asserting that
+the `status.readyReplicas` gets updated to 1.
+
+file `testdata/manifests/nginx-deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+```
+
+file `testdata/apply-deployment.yaml`:
+
+```yaml
+name: apply-deployment
+description: create, get, apply a change, get, delete a Deployment
+require:
+  - kind
+tests:
+  - name: create-deployment
+    kube:
+      create: testdata/manifests/nginx-deployment.yaml
+  - name: deployment-has-2-replicas
+    timeout:
+      after: 20s
+    kube:
+      get: deployments/nginx
+      assert:
+        matches:
+          status:
+            readyReplicas: 2
+  - name: apply-deployment-change
+    kube:
+      apply: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nginx
+        spec:
+          replicas: 1
+  - name: deployment-has-1-replica
+    timeout:
+      after: 20s
+    kube:
+      get: deployments/nginx
+      assert:
+        matches:
+          status:
+            readyReplicas: 1
+  - name: delete-deployment
+    kube:
+      delete: deployments/nginx
 ```
 
 ### Timeouts and retrying `kube.get` assertions

--- a/parse.go
+++ b/parse.go
@@ -229,17 +229,17 @@ func validateResourceIdentifier(subject string) error {
 //
 // The following formats for a resource identifier string are allowed:
 //
-// * "pods" - pluralized resource type, refers to a collection of Pod resources
-// * "po" - shortname of a resource type, refers to a collection of Pod
-//   resources
-// * "pod" - singular of a resource type, refers to a collection of Pod
-//   resources (because no resource name has been specified)
-// * "pods/my-pod" - pluralized resource type along with a resource name,
-//   refers to a single Pod resource with the name "my-pod"
-// * "pod/my-pod" - singular resource type along with a resource name,
-//   refers to a single Pod resource with the name "my-pod"
-// * "po/my-pod" - shortname of a resource type along with a resource name,
-//   refers to a single Pod resource with the name "my-pod"
+//   - "pods" - pluralized resource type, refers to a collection of Pod resources
+//   - "po" - shortname of a resource type, refers to a collection of Pod
+//     resources
+//   - "pod" - singular of a resource type, refers to a collection of Pod
+//     resources (because no resource name has been specified)
+//   - "pods/my-pod" - pluralized resource type along with a resource name,
+//     refers to a single Pod resource with the name "my-pod"
+//   - "pod/my-pod" - singular resource type along with a resource name,
+//     refers to a single Pod resource with the name "my-pod"
+//   - "po/my-pod" - shortname of a resource type along with a resource name,
+//     refers to a single Pod resource with the name "my-pod"
 func resourceTypeAndNameFromIdentifier(identifier string) (string, string) {
 	rt := ""
 	rn := ""

--- a/run.go
+++ b/run.go
@@ -28,6 +28,9 @@ const (
 	// defaultGetTimeout is used as a retry max time if the spec's Timeout has
 	// not been specified.
 	defaultGetTimeout = time.Second * 5
+	// fieldManagerName is the identifier for the field manager we specify in
+	// Apply requests.
+	fieldManagerName = "gdt-kube"
 )
 
 // Run executes the test described by the Kubernetes test. A new Kubernetes
@@ -46,6 +49,9 @@ func (s *Spec) Run(ctx context.Context, t *testing.T) error {
 		}
 		if s.Kube.Delete != "" {
 			err = s.runDelete(ctx, t, c)
+		}
+		if s.Kube.Apply != "" {
+			err = s.runApply(ctx, t, c)
 		}
 	})
 	return result.New(
@@ -213,6 +219,73 @@ func (s *Spec) runCreate(
 		)
 		// TODO(jaypipes): Clearly this is applying the same assertion to each
 		// object that was created, which is wrong. When I add the polymorphism
+		// to the Assertions struct, I will modify this block to look for an
+		// indexed set of error assertions.
+		a = newAssertions(s.Kube.Assert, err, obj)
+		if !a.OK() {
+			for _, f := range a.Failures() {
+				t.Error(f)
+			}
+		}
+	}
+	return nil
+}
+
+// runApply executes an Apply() call against the Kubernetes API server and
+// evaluates any assertions that have been set for the returned results.
+func (s *Spec) runApply(
+	ctx context.Context,
+	t *testing.T,
+	c *connection,
+) error {
+	var err error
+	var r io.Reader
+	if probablyFilePath(s.Kube.Apply) {
+		path := s.Kube.Apply
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		r = f
+	} else {
+		// Consider the string to be YAML/JSON content and marshal that into an
+		// unstructured.Unstructured that we then pass to Apply()
+		r = strings.NewReader(s.Kube.Apply)
+	}
+
+	objs, err := unstructuredFromReader(r)
+	if err != nil {
+		return err
+	}
+	for _, obj := range objs {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		ns := obj.GetNamespace()
+		if ns == "" {
+			ns = s.Namespace()
+		}
+		res, err := c.gvrFromGVK(gvk)
+		a := newAssertions(s.Kube.Assert, err, nil)
+		if !a.OK() {
+			for _, f := range a.Failures() {
+				t.Error(f)
+			}
+			return nil
+		}
+		obj, err := c.client.Resource(res).Namespace(ns).Apply(
+			ctx,
+			// NOTE(jaypipes): Not sure why a separate name argument is
+			// necessary considering `obj` is of type
+			// `*unstructured.Unstructured` and therefore has the `GetName()`
+			// method...
+			obj.GetName(),
+			obj,
+			// TODO(jaypipes): Not sure if this hard-coded options struct is
+			// always going to work. Maybe add ability to control it?
+			metav1.ApplyOptions{FieldManager: fieldManagerName, Force: true},
+		)
+		// TODO(jaypipes): Clearly this is applying the same assertion to each
+		// object that was applied, which is wrong. When I add the polymorphism
 		// to the Assertions struct, I will modify this block to look for an
 		// indexed set of error assertions.
 		a = newAssertions(s.Kube.Assert, err, obj)

--- a/run_test.go
+++ b/run_test.go
@@ -252,7 +252,33 @@ func TestMatches(t *testing.T) {
 
 	kfix := kindfix.New()
 
-	ctx := gdtcontext.New(gdtcontext.WithDebug(os.Stdout))
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
+	ctx = gdtcontext.RegisterFixture(ctx, "kind", kfix)
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+		scenario.WithContext(ctx),
+	)
+	require.Nil(err)
+	require.NotNil(s)
+
+	err = s.Run(ctx, t)
+	require.Nil(err, "%s", err)
+}
+
+func TestApply(t *testing.T) {
+	skipIfKind(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "apply-deployment.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	kfix := kindfix.New()
+
+	ctx := gdtcontext.New()
 	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
 	ctx = gdtcontext.RegisterFixture(ctx, "kind", kfix)
 

--- a/testdata/apply-deployment.yaml
+++ b/testdata/apply-deployment.yaml
@@ -1,0 +1,38 @@
+name: apply-deployment
+description: create, get, apply a change, get, delete a Deployment
+require:
+  - kind
+tests:
+  - name: create-deployment
+    kube:
+      create: testdata/manifests/nginx-deployment.yaml
+  - name: deployment-has-2-replicas
+    timeout:
+      after: 20s
+    kube:
+      get: deployments/nginx
+      assert:
+        matches:
+          status:
+            readyReplicas: 2
+  - name: apply-deployment-change
+    kube:
+      apply: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nginx
+        spec:
+          replicas: 1
+  - name: deployment-has-1-replica
+    timeout:
+      after: 20s
+    kube:
+      get: deployments/nginx
+      assert:
+        matches:
+          status:
+            readyReplicas: 1
+  - name: delete-deployment
+    kube:
+      delete: deployments/nginx

--- a/testdata/matches.yaml
+++ b/testdata/matches.yaml
@@ -6,7 +6,7 @@ tests:
   - name: create-deployment
     kube:
       create: testdata/manifests/nginx-deployment.yaml
-  - name: deployment-exists
+  - name: deployment-matches-expected-fields
     timeout:
       after: 20s
     kube:


### PR DESCRIPTION
Adds support for the `kube.apply` action which performs a Kubernetes Apply API call against either a YAML file or an inline string of YAML:

```yaml
name: apply-deployment
description: create, get, apply a change, get, delete a Deployment
require:
  - kind
tests:
  - name: create-deployment
    kube:
      create: testdata/manifests/nginx-deployment.yaml
  - name: deployment-has-2-replicas
    timeout:
      after: 20s
    kube:
      get: deployments/nginx
      assert:
        matches:
          status:
            readyReplicas: 2
  - name: apply-deployment-change
    kube:
      apply: |
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: nginx
        spec:
          replicas: 1
  - name: deployment-has-1-replica
    timeout:
      after: 20s
    kube:
      get: deployments/nginx
      assert:
        matches:
          status:
            readyReplicas: 1
  - name: delete-deployment
    kube:
      delete: deployments/nginx
```