### PR TITLE
add support for `kube.assert.json` assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ matches some expectation:
   the value of the fields match. Only scalar fields are matched entirely.
   In other words, you do not need to specify every field of a struct field
   in order to compare the value of a single field in the nested struct.
+* `kube.assert.json`: (optional) object describing the assertions to make about
+  resource(s) returned from the `kube.get` call to the Kubernetes API server.
+* `kube.assert.json.len`: (optional) integer representing the number of bytes in the
+  resulting JSON object after successfully parsing the resource.
+* `kube.assert.json.paths`: (optional) map of strings where the keys of the map
+  are JSONPath expressions and the values of the map are the expected value to
+  be found when evaluating the JSONPath expression
+* `kube.assert.json.path_formats`: (optional) map of strings where the keys of the map are
+  JSONPath expressions and the values of the map are the expected format of the
+  value to be found when evaluating the JSONPath expression. See the
+  [list of valid format strings](#valid-format-strings)
+* `kube.assert.json.schema`: (optional) string containing a filepath to a
+  JSONSchema document.  If present, the resource's structure will be validated
+  against this JSONSChema document.
+
+## Examples
 
 Here are some examples of `gdt-kube` tests.
 
@@ -263,8 +279,14 @@ tests:
 
 ### Asserting resource fields using `kube.assert.matches`
 
-A test that checks that a Deployment resource's `Status.ReadyReplicas` field
-is `2`. You do not need to specify all other `Deployment.Status` fields like
+The `kube.assert.matches` field of a `gdt-kube` test Spec allows a test author
+to specify expected fields and those field contents in a resource that was
+returned by the Kubernetes API server from the result of a `kube.get` call.
+
+Suppose you have a Deployment resource and you want to write a test that checks
+that a Deployment resource's `Status.ReadyReplicas` field is `2`.
+
+You do not need to specify all other `Deployment.Status` fields like
 `Status.Replicas` in order to match the `Status.ReadyReplicas` field value. You
 only need to include the `Status.ReadyReplicas` field in the `Matches` value as
 these examples demonstrate:
@@ -309,6 +331,88 @@ tests:
        matches:
          status:
            readyReplicas: 2
+```
+
+### Asserting resource fields using `kube.assert.json`
+
+The `kube.assert.json` field of a `gdt-kube` test Spec allows a test author to
+specify expected fields, the value of those fields as well as the format of
+field values in a resource that was returned by the Kubernetes API server from
+the result of a `kube.get` call.
+
+Suppose you have a Deployment resource and you want to write a test that checks
+that a Deployment resource's `Status.ReadyReplicas` field is `2`.
+
+You can specify this expectation using the `kube.assert.json.paths` field,
+which is a `map[string]interface{}` that takes map keys that are JSONPath
+expressions and map values of what the field at that JSONPath expression should
+contain:
+
+```yaml
+tests:
+ - name: check deployment's ready replicas is 2
+   kube:
+     get: deployments/my-deployment
+     assert:
+       json:
+        paths:
+          $.status.readyReplicas: 2 
+```
+
+JSONPath expressions can be fairly complex, allowing the test author to, for
+example, assert the value of a nested map field with a particular key, as this
+example shows:
+
+```yaml
+tests:
+ - name: check deployment's pod template "app" label is "nginx"
+   kube:
+     get: deployments/my-deployment
+     assert:
+       json:
+        paths:
+          $.spec.template.labels["app"]: nginx
+```
+
+You can check that the value of a particular field at a JSONPath is formatted
+in a particular fashion using `kube.assert.json.path_formats`. This is a map,
+keyed by JSONPath expression, of the data format the value of the field at that
+JSONPath expression should have. Valid data formats are:
+
+* `date`
+* `date-time`
+* `email`
+* `hostname`
+* `idn-email`
+* `ipv4`
+* `ipv6`
+* `iri`
+* `iri-reference`
+* `json-pointer`
+* `regex`
+* `relative-json-pointer`
+* `time`
+* `uri`
+* `uri-reference`
+* `uri-template`
+* `uuid`
+* `uuid4`
+
+[Read more about JSONSchema formats](https://json-schema.org/understanding-json-schema/reference/string.html#built-in-formats).
+
+For example, suppose we wanted to verify that a Deployment's `metadata.uid`
+field was a UUID-4 and that its `metadata.creationTimestamp` field was a
+date-time timestamp:
+
+```yaml
+tests:
+  - kube:
+      get: deployments/nginx
+      assert:
+        json:
+          path_formats:
+            $.metadata.uid: uuid4
+            $.metadata.creationTimestamp: date-time
 ```
 
 ### Updating a resource and asserting corresponding field changes

--- a/assertions.go
+++ b/assertions.go
@@ -5,11 +5,13 @@
 package kube
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	gdtjson "github.com/jaypipes/gdt-core/assertion/json"
 	gdterrors "github.com/jaypipes/gdt-core/errors"
 	gdttypes "github.com/jaypipes/gdt-core/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -97,6 +99,9 @@ type Expect struct {
 	//            readyReplicas: 2
 	// ```
 	Matches interface{} `yaml:"matches,omitempty"`
+	// JSON contains the assertions about JSON data in a response from the
+	// Kubernetes API server.
+	JSON *gdtjson.Expect `yaml:"json,omitempty"`
 }
 
 // assertions contains all assertions made for the exec test
@@ -159,6 +164,9 @@ func (a *assertions) OK() bool {
 		return false
 	}
 	if !a.matchesOK() {
+		return false
+	}
+	if !a.jsonOK() {
 		return false
 	}
 	return true
@@ -298,6 +306,34 @@ func (a *assertions) matchesOK() bool {
 		//		return false
 		//	}
 		//}
+	}
+	return true
+}
+
+// jsonOK returns true if the subject matches the JSON conditions, false
+// otherwise
+func (a *assertions) jsonOK() bool {
+	exp := a.exp
+	if exp.JSON != nil && a.hasSubject() {
+		var err error
+		var b []byte
+		res, ok := a.r.(*unstructured.Unstructured)
+		if ok {
+			if b, err = json.Marshal(res); err != nil {
+				panic("unable to marshal unstructured.Unstructured")
+			}
+		}
+		ja := gdtjson.New(exp.JSON, b)
+		if !ja.OK() {
+			// TODO(jaypipes): Re-enable this when update gdt-core
+			// `JSONAssertions.Terminal()` to not throw terminal error when
+			// things like JSONPath keys are not found.
+			// a.terminal = ja.Terminal()
+			for _, f := range ja.Failures() {
+				a.Fail(f)
+			}
+			return false
+		}
 	}
 	return true
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
+	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
@@ -47,6 +49,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,11 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
@@ -206,6 +211,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/run_test.go
+++ b/run_test.go
@@ -268,6 +268,32 @@ func TestMatches(t *testing.T) {
 	require.Nil(err, "%s", err)
 }
 
+func TestJSON(t *testing.T) {
+	skipIfKind(t)
+	require := require.New(t)
+
+	fp := filepath.Join("testdata", "json.yaml")
+	f, err := os.Open(fp)
+	require.Nil(err)
+
+	kfix := kindfix.New()
+
+	ctx := gdtcontext.New()
+	ctx = gdtcontext.RegisterPlugin(ctx, gdtkube.Plugin())
+	ctx = gdtcontext.RegisterFixture(ctx, "kind", kfix)
+
+	s, err := scenario.FromReader(
+		f,
+		scenario.WithPath(fp),
+		scenario.WithContext(ctx),
+	)
+	require.Nil(err)
+	require.NotNil(s)
+
+	err = s.Run(ctx, t)
+	require.Nil(err, "%s", err)
+}
+
 func TestApply(t *testing.T) {
 	skipIfKind(t)
 	require := require.New(t)

--- a/testdata/json.yaml
+++ b/testdata/json.yaml
@@ -1,0 +1,25 @@
+name: json
+description: create a deployment and check the json condition succeeds
+require:
+  - kind
+tests:
+  - name: create-deployment
+    kube:
+      create: testdata/manifests/nginx-deployment.yaml
+  - name: deployment-json-assertions
+    timeout:
+      after: 20s
+    kube:
+      get: deployments/nginx
+      assert:
+        json:
+          paths:
+            $.spec.replicas: 2
+            $.spec.template.metadata.labels["app"]: nginx
+            $.status.readyReplicas: 2
+          path_formats:
+            $.metadata.uid: uuid4
+            $.metadata.creationTimestamp: date-time
+  - name: delete-deployment
+    kube:
+      delete: deployments/nginx


### PR DESCRIPTION
Adds support for specifying expected field, field value, and field value formats using the `gdt-core` `assertion/json.Expect` struct.

Expectations of field to find (and an expected value of that field) in a Kubernetes resource can now be specified using `kube.assert.json.paths`, like this example illustrates:

```yaml
tests:
 - name: check deployment's ready replicas is 2
   kube:
     get: deployments/my-deployment
     assert:
       json:
        paths:
          $.status.readyReplicas: 2
```

JSONPath expressions can be fairly complex, allowing the test author to, for example, assert the value of a nested map field with a particular key, as this example shows:

```yaml
tests:
 - name: check deployment's pod template "app" label is "nginx"
   kube:
     get: deployments/my-deployment
     assert:
       json:
        paths:
          $.spec.template.labels["app"]: nginx
```

You can check that the value of a particular field at a JSONPath is formatted in a particular fashion using `kube.assert.json.path_formats`. This is a map, keyed by JSONPath expression, of the data format the value of the field at that JSONPath expression should have.

For example, suppose we wanted to verify that a Deployment's `metadata.uid` field was a UUID-4 and that its `metadata.creationTimestamp` field was a date-time timestamp:

```yaml
tests:
  - kube:
      get: deployments/nginx
      assert:
        json:
          path_formats:
            $.metadata.uid: uuid4
            $.metadata.creationTimestamp: date-time
```

Closes Issue #5